### PR TITLE
fix: inherit semantic commit type from internal dependency updates

### DIFF
--- a/base.json
+++ b/base.json
@@ -25,7 +25,7 @@
 
   "packageRules": [
     {
-      "$comment": "handle LLK packages first (higher priority) and exempt them from stabilityDays requirement",
+      "$comment": "handle internal dependencies first (higher priority) and exempt them from stabilityDays requirement",
       "matchSourceUrlPrefixes": [
         "git+https://github.com/LLK/",
         "git+ssh://git@github.com/LLK/",
@@ -34,7 +34,15 @@
         "https://github.com/LLK/"
       ],
       "prPriority": 5,
-      "stabilityDays": 0
+      "stabilityDays": 0,
+      "minor": {
+        "$comment": "A minor bump to an internal dependency should cause a minor bump in this package's version",
+        "semanticCommitType": "feat"
+      },
+      "patch": {
+        "$comment": "A patch bump to an internal dependency should cause a patch bump in this package's version",
+        "semanticCommitType": "fix"
+      }
     }
   ]
 }

--- a/conservative.json
+++ b/conservative.json
@@ -7,7 +7,7 @@
 
   "packageRules": [
     {
-      "$comment": "enable auto-merge for minor & patch updates of LLK packages which use semver",
+      "$comment": "enable auto-merge for minor & patch updates of internal dependencies which use semver",
       "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["minor", "patch"],
       "matchSourceUrlPrefixes": [
@@ -21,7 +21,7 @@
       "rebaseWhen": "behind-base-branch"
     },
     {
-      "$comment": "enable auto-merge for all updates of LLK packages which don't yet use semver",
+      "$comment": "enable auto-merge for all updates of internal dependencies which don't yet use semver",
       "matchCurrentVersion": "/^0.*-prerelease/",
       "matchSourceUrlPrefixes": [
         "git+https://github.com/LLK/",

--- a/default.json
+++ b/default.json
@@ -14,7 +14,7 @@
       "rebaseWhen": "behind-base-branch"
     },
     {
-      "$comment": "enable auto-merge for all updates of LLK packages which don't yet use semver",
+      "$comment": "enable auto-merge for all updates of internal dependencies which don't yet use semver",
       "matchCurrentVersion": "/^0.*-prerelease/",
       "matchSourceUrlPrefixes": [
         "git+https://github.com/LLK/",


### PR DESCRIPTION
### Proposed Changes

Adjust comments to discuss "internal dependencies" instead of specifically "LLK packages."

Add two new rules for internal dependencies:

* A PR for a minor bump of an internal dependency will now be marked "feat"
* A PR for a patch bump of an internal dependency will now be marked "fix"

### Reason for Changes

For the "internal dependencies" phrasing change: we'll be migrating from `LLK` to `scratchfoundation` so I wanted to make the comments cover both. I'm not super happy with this way to phrase it, so I'm open to suggestions if you have another idea.

By default, all dependency updates are committed with "chore(deps)" which, by default, does not cause a version bump with `semantic-release`. This change causes internal dependency updates to be treated differently such that the semantic commit type is inherited. For example, if scratch-vm updates from 3.1.4 to 3.2.0, a minor bump indicating a feature update, then the corresponding PR in scratch-gui will be marked "feat" to cause a corresponding minor bump in scratch-gui.

Without this change, updates to internal dependencies will be "merged up the chain" as expected but they will not trigger a release.

There is no special rule for major version bumps since those are not auto-merged and, presumably, will require a non-Renovate change to merge correctly.

### Test Coverage

Passes `renovate-config-validator`.